### PR TITLE
Transfer id to geojson file when id found in topojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Depends on [shapely](https://pypi.org/project/Shapely/) and [click](https://pypi
 [~]$ topo2geo input_topo.json output_geo.json
 ```
 
+### Troubleshooting
+If you experience a "segmentation fault" one thing to try is explained [here](https://pypi.org/project/Shapely/):
+```
+pip install shapely --no-binary shapely         
+```
 ### Credits
 Originally written by [sgillies](https://github.com/sgillies) and [perrygeo](https://github.com/perrygeo). Converted to Python3 and packaged into a CLI by [kylepollina](https://github.com/kylepollina).
 

--- a/topo2geo/core.py
+++ b/topo2geo/core.py
@@ -122,6 +122,9 @@ def to_geojson(topojson_path):
     fc = {'type': "FeatureCollection", 'features': []}
 
     for index, feature in enumerate(features):
+        if feature.get('id'):
+            index = feature.get('id')
+
         f = {'id': index, 'type': "Feature"}
         f['properties'] = feature['properties'].copy()
 


### PR DESCRIPTION
ID is typically an import piece of information, for example it could be a FIPS code. 
What do you think about transferring over the id?