### PR TITLE
Split multilayered topojsons into multiple geojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ Depends on [shapely](https://pypi.org/project/Shapely/) and [click](https://pypi
 [~]$ topo2geo input_topo.json output_geo.json
 ```
 
+### Multilayered Topojsons
+If the topojson contains mulitple layers (i.e. there are multiple values in the "objects" key). Then seperate geojson files will be output prefixed with the layer name. 
+
+For example a topojson containing states and counties:
+{
+    "type": "Topology",
+    "objects": {
+        "county": {
+            "type": "GeometryCollection",
+            .....
+                  },
+        "state": {
+            "type": "GeometryCollection",
+            .....
+                  }
+               }
+}
+would produce two geojson files, county_output_geo.json and state_output_geo.json.
+
 ### Troubleshooting
 If you experience a "segmentation fault" one thing to try is explained [here](https://pypi.org/project/Shapely/):
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Depends on [shapely](https://pypi.org/project/Shapely/) and [click](https://pypi
 ```
 
 ### Multilayered Topojsons
-If the topojson contains mulitple layers (i.e. there are multiple values in the "objects" key). Then seperate geojson files will be output prefixed with the layer name. 
+If the topojson contains mulitple layers (i.e. there are multiple values in the "objects" key). Then seperate geojson files will be output with the layer name. 
 
 For example a topojson containing states and counties:
 {
@@ -34,7 +34,7 @@ For example a topojson containing states and counties:
                   }
                }
 }
-would produce two geojson files, county_output_geo.json and state_output_geo.json.
+would produce two geojson files, output_geo_county.json and output_geo_state.json.
 
 ### Troubleshooting
 If you experience a "segmentation fault" one thing to try is explained [here](https://pypi.org/project/Shapely/):

--- a/topo2geo/core.py
+++ b/topo2geo/core.py
@@ -37,9 +37,14 @@ def main(input_file, output_file):
     geojson_layers = to_geojson(input_file)
 
     for layer, geojson in geojson_layers.items():
+        if len(geojson_layers.keys()) > 1:
+            geojson_fn = f'{layer}_{output_file}'
+        else:
+            geojson_fn = output_file
+
         try:
-            with open(f'{layer}_{output_file}', 'w+') as dest:
-                dest.write(json.dumps(geojson))
+            with open(geojson_fn, 'w+') as dest:
+                dest.write(json.dumps(geojson, indent=4))
         except AssertionError:
             print('Error: Invalid TopoJSON')
         except ValueError as e:
@@ -119,7 +124,7 @@ def to_geojson(topojson_path):
     scale = topology['transform']['scale']
     translate = topology['transform']['translate']
 
-    seperate_layers = {}
+    geojson_layers = {}
     for layer in layers:
         features = topology['objects'][layer]['geometries']
 
@@ -139,6 +144,6 @@ def to_geojson(topojson_path):
 
             fc['features'].append(f)
 
-        seperate_layers[layer] = fc
+        geojson_layers[layer] = fc
 
-    return seperate_layers
+    return geojson_layers

--- a/topo2geo/core.py
+++ b/topo2geo/core.py
@@ -36,9 +36,11 @@ def main(input_file, output_file):
 
     geojson_layers = to_geojson(input_file)
 
+    output_filename, output_extension = os.path.splitext(output_file)
+
     for layer, geojson in geojson_layers.items():
         if len(geojson_layers.keys()) > 1:
-            geojson_fn = f'{layer}_{output_file}'
+            geojson_fn = f'{output_filename}_{layer}{output_extension}'
         else:
             geojson_fn = output_file
 


### PR DESCRIPTION
Topojson's can have multiple layers. 
Currently, only the first layer, and no subsequent layers, in a topojson is converted. 
With this PR each layer is converted into separate geojson files; increasing the code utility for multilayered topojson files. The output files are prefixed with each layers name. See example in README.md
No changes are made to the output file name when the topojson to be converted is a single layer.

