### PR TITLE
Update some issues I came across

### DIFF
--- a/topo2geo/core.py
+++ b/topo2geo/core.py
@@ -7,7 +7,7 @@ import json
 from itertools import chain
 
 import click
-from shapely.geometry import asShape
+from shapely.geometry import shape
 
 from . import version as VERSION
 
@@ -73,8 +73,15 @@ def topo2geo(input_file: str, output_file: str) -> None:
 def build_geojson_layers(topology: dict) -> dict:
     """Convert the data in the topology dict to GeoJSON"""
     layers = list(topology['objects'].keys())
-    scale = topology['transform']['scale']
-    translate = topology['transform']['translate']
+    if 'transform' in topology and 'scale' in topology['transform']:
+        scale = topology['transform']['scale']
+    else:
+        scale = None
+
+    if 'transform' in topology and 'translate' in topology['transform']:
+        translate = topology['transform']['translate']
+    else:
+        translate = None
 
     geojson_layers = {}
     for layer in layers:
@@ -90,7 +97,7 @@ def build_geojson_layers(topology: dict) -> dict:
             f['properties'] = feature['properties'].copy()
 
             geommap = geometry(feature, topology['arcs'], scale, translate)
-            geom = asShape(geommap).buffer(0)
+            geom = shape(geommap).buffer(0)
             assert geom.is_valid
             f['geometry'] = geom.__geo_interface__
 


### PR DESCRIPTION
For the first change, `asShape` and similar functions were deprecated in shapely 2.0+: https://shapely.readthedocs.io/en/stable/migration.html#other-deprecated-functionality

For the remaining changes, I have a topojson file that does not have `scale` nor `translate`, and they also don't seem to be required. Making the changes seemed to work fine for me, so forwarding them along.